### PR TITLE
fix: don't build cdylib when testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 arrow = "53.4"
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = "0.21"
 pyo3-arrow = "0.3"
 chrono = "0.4"
 blake3 = "1.5"
@@ -15,6 +15,9 @@ ordered-float = "4.2"
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "cargo_bench_support"] }
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
+
+[features]
+py-ext = ["pyo3/extension-module"]
 
 [lib]
 name = "bitemporal_timeseries"
@@ -26,3 +29,4 @@ lto = true
 [[bench]]
 name = "bitemporal_benchmarks"
 harness = false
+


### PR DESCRIPTION
Fixes #1 

On macOS a cdylib that exposes Python API symbols must either link to a Python framework/lib or be built with -undefined dynamic_lookup. Because those flags aren’t present in the 'cargo test', the cdylib link step sees unresolved Py* symbols and the build fails.

This change pushes the cdylib to a feature flag. maturin knows to enable the pyo3/extension-module